### PR TITLE
Fix #358: Evaluate on test instead of validation dataset

### DIFF
--- a/Donut/CORD/Fine_tune_Donut_on_a_custom_dataset_(CORD)_with_PyTorch_Lightning.ipynb
+++ b/Donut/CORD/Fine_tune_Donut_on_a_custom_dataset_(CORD)_with_PyTorch_Lightning.ipynb
@@ -8233,7 +8233,7 @@
         "output_list = []\n",
         "accs = []\n",
         "\n",
-        "dataset = load_dataset(\"naver-clova-ix/cord-v2\", split=\"validation\")\n",
+        "dataset = load_dataset(\"naver-clova-ix/cord-v2\", split=\"test\")\n",
         "\n",
         "for idx, sample in tqdm(enumerate(dataset), total=len(dataset)):\n",
         "    # prepare encoder inputs\n",


### PR DESCRIPTION
Just a tiny PR to fix an error on the CORD Donut finetuning notebook. See #358 for a description of the problem